### PR TITLE
Removing the time check on playHandler

### DIFF
--- a/src/production_lib/bcc_adobe_analytics.js
+++ b/src/production_lib/bcc_adobe_analytics.js
@@ -1119,7 +1119,7 @@ function s_pgicq(){var a=window,k=a.s_giq,q,r,n;if(k)for(q=0;q<k.length;q++)r=k[
 		var that = this;
 		
 		// set up the analytics when a video begins playback if it has not yet begun
-		if (!this._hasLoad && this._player.currentTime() == 0) {
+		if (!this._hasLoad) {
 			o_debug("Player Debug: Replay existing video");
 			this._hasLoad = true;
 			


### PR DESCRIPTION
Hi guys,

I'm currently working on implementing Video analytics with Brightcove. Sometimes, it seems like the video analytics are not firing in time. In fact, the video timer is not always at 0 when the video first play (because of ads generally or other plugin being added)

I'm thinking of doing what is in that PR for my project, but I wanted to know if you would see any potential errors coming out of that change ?

Thank you very much.
